### PR TITLE
Mix task to push firmware

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,12 @@
+use Mix.Config
+
+# config :nerves_firmware_ssh,
+#   authorized_keys: [
+#     "ssh-rsa 12345== abcd",
+#     "ssh-rsa 67890== fghi",
+#   ],
+#   system_dir: "/etc/ssh"
+
+# The keys located in /etc/ssh should be named
+#  ssh_host_rsa_key
+#  ssh_host_rsa_key.pub

--- a/lib/mix/tasks/firmware.push.ex
+++ b/lib/mix/tasks/firmware.push.ex
@@ -1,0 +1,127 @@
+defmodule Mix.Tasks.Firmware.Push do
+  use Mix.Task
+
+  @shortdoc "Pushes firmware to a Nerves device over SSH"
+
+  @moduledoc """
+  Pushes firmware to a Nerves device.
+
+  This task will take a fw file path passed as --firmware or discover it from
+  a target passed as --target.
+
+  ## Command line options
+
+   * `--target` - The target string of the target configuration.
+   * `--firmware` - The path to a fw file.
+   * `--user-dir` - The path to where your id_rsa id_rsa.pub key files are located.
+
+  For example, to push firmware to a device at an IP by specifying a fw file
+
+    mix firmware.push 192.168.1.120 --firmware _images/rpi3/my_app.fw
+
+  Or by discovering it with the target
+
+    mix firmware.push 192.168.1.120 --target rpi3
+
+  """
+
+  @switches [firmware: :string, target: :string, port: :integer, user_dir: :string]
+  def run([ip | argv]) do
+    {opts, _, _} = OptionParser.parse(argv, switches: @switches)
+    user_dir = opts[:user_dir] || "~/.ssh"
+    user_dir = Path.expand(user_dir) |> to_char_list
+    fwfile = firmware(opts)
+    port = opts[:port] || 8989
+    stats = File.stat!(fwfile)
+    fwsize = stats.size
+    Application.ensure_all_started(:ssh)
+    connect_opts = [silently_accept_hosts: true, user_dir: user_dir]
+    connect_opts =
+      if passphrase = opts[:rsa_pass_phrase] do
+        Keyword.put(connect_opts, :rsa_pass_phrase, passphrase)
+      else
+        connect_opts
+      end
+
+    {:ok, connection_ref} = :ssh.connect(to_char_list(ip), port, connect_opts)
+    {:ok, channel_id} = :ssh_connection.session_channel(connection_ref, :infinity)
+    :success = :ssh_connection.subsystem(connection_ref, channel_id, 'nerves_firmware_ssh', :infinity)
+    :ok = :ssh_connection.send(connection_ref, channel_id, "fwup:#{fwsize},reboot\n")
+
+    chunks =
+      File.open!(fwfile, [:read])
+      |> IO.binstream(16384)
+
+    wait_for_complete(connection_ref, channel_id, chunks)
+  end
+
+  #find the firmware
+
+  defp firmware(opts) do
+    if fw = opts[:firmware] do
+      fw |> Path.expand
+    else
+      discover_firmware(opts)
+    end
+  end
+
+  defp discover_firmware(opts) do
+    target = opts[:target] || System.get_env("MIX_TARGET") || Mix.raise """
+    You must pass either firmware or target
+    Examples:
+      $ export MIX_TARGET=rpi0
+      $ mix firmware.push rpi0.local
+    Or
+      $ mix firmware.push rpi0.local --firmware path/to/app.fw
+      $ mix firmware.push rpi0.local --target rpi0
+    """
+
+    project = Mix.Project.get
+
+    :code.delete(project)
+    :code.purge(project)
+    level = Logger.level
+    Logger.configure(level: :error)
+    Application.stop(:mix)
+    System.put_env("MIX_TARGET", target)
+    Application.start(:mix)
+    Logger.configure(level: level)
+
+    Mix.Project.in_project(project, File.cwd!, fn(_module) ->
+      target = Mix.Project.config[:target]
+      app = Mix.Project.config[:app]
+      images_path =
+        (Mix.Project.config[:images_path] ||
+        Path.join([Mix.Project.build_path, "nerves", "images"]) ||
+        "_images/#{target}")
+      Path.join([images_path, "#{app}.fw"])
+      |> Path.expand
+    end)
+  end
+
+  defp wait_for_complete(connection_ref, channel_id, chunks) do
+    timeout =
+      case Enum.take(chunks, 1) do
+        [chunk] ->
+          :ok = :ssh_connection.send(connection_ref, channel_id, chunk)
+          0
+        [] ->
+          10_000
+      end
+
+    receive do
+      {:ssh_cm, _connection_ref, {:data, 0, 0, message}} ->
+        IO.write(message)
+        IO.write("")
+        wait_for_complete(connection_ref, channel_id, chunks)
+      {:ssh_cm, _connection_ref, {:eof, 0}} ->
+        # Ignore.
+        wait_for_complete(connection_ref, channel_id, chunks)
+      {:ssh_cm, _connection_ref, {:closed, 0}} ->
+        :ok
+    after
+      timeout ->
+        wait_for_complete(connection_ref, channel_id, chunks)
+    end
+  end
+end

--- a/lib/nerves_firmware_ssh/application.ex
+++ b/lib/nerves_firmware_ssh/application.ex
@@ -16,7 +16,10 @@ defmodule Nerves.Firmware.SSH.Application do
 
   def init() do
     port = Application.get_env(:nerves_firmware_ssh, :port, 8989)
-    authorized_keys = Application.get_env(:nerves_firmware_ssh, :authorized_keys, "")
+    system_dir = Application.get_env(:nerves_firmware_ssh, :system_dir, "/etc/ssh")
+    authorized_keys =
+      Application.get_env(:nerves_firmware_ssh, :authorized_keys, [])
+      |> Enum.join("\n")
     decoded_authorized_keys = :public_key.ssh_decode(authorized_keys, :auth_keys)
 
     cb_opts = [authorized_keys: decoded_authorized_keys]
@@ -26,7 +29,7 @@ defmodule Nerves.Firmware.SSH.Application do
         {:max_sessions, 1},
         {:id_string, :random},
         {:key_cb, {Nerves.Firmware.SSH.Keys, cb_opts}},
-        {:system_dir, :code.priv_dir(:nerves_firmware_ssh)}, # FIXME
+        {:system_dir, to_char_list(system_dir)},
         {:subsystems, [{'nerves_firmware_ssh', {Nerves.Firmware.SSH.Handler, []}}]}
       ])
   end

--- a/lib/nerves_firmware_ssh/handler.ex
+++ b/lib/nerves_firmware_ssh/handler.ex
@@ -46,9 +46,18 @@ defmodule Nerves.Firmware.SSH.Handler do
     {:stop, channel_id, state}
   end
 
+  def handle_ssh_msg({:ssh_cm, _cm, _message}, state) do
+    {:ok, state}
+  end
+
+
+
   def handle_cast({:fwup_data, response}, state) do
-    :ok = :ssh_connection.send(state.cm, state.id, response)
-    {:noreply, state}
+    case :ssh_connection.send(state.cm, state.id, response) do
+      :ok -> {:noreply, state}
+      {:error, reason} -> {:stop, reason}
+    end
+
   end
   def handle_cast({:fwup_exit, 0}, state) do
     buffer = state.buffer

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,3 @@
+%{"elixir_make": {:hex, :elixir_make, "0.4.0", "992f38fabe705bb45821a728f20914c554b276838433349d4f2341f7a687cddf", [:mix], []},
+  "nerves_runtime": {:hex, :nerves_runtime, "0.4.1", "47985a7c4a79f4374bf42760192ce7b49b87859538836052037f0ce2b8b7dc4d", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, optional: false]}, {:system_registry, "~> 0.3", [hex: :system_registry, optional: false]}]},
+  "system_registry": {:hex, :system_registry, "0.4.0", "d8a7267005418efd8291df327153ae6f11badcb7a8827dd00ed59dc9abb3f9a6", [:mix], []}}


### PR DESCRIPTION
Adds `mix firmware.push nerves.local`
Fixed issue with ssh handler not handle disconnects gracefully
Allow opts to be passed in.