### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ may be helpful. Here's an example:
 
 ```
 config :nerves_firmware_ssh,
-  authorized_keys: """
-  ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQDBCdMwNo0xOE86il0DB2Tq4RCv07XvnV7W1uQBlOOE0ZZVjxmTIOiu8XcSLy0mHj11qX5pQH3Th6Jmyqdj
-  ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCaf37TM8GfNKcoDjoewa6021zln4GvmOiXqW6SRpF61uNWZXurPte1u8frrJX1P/hGxCL7YN3cV6eZqRiF
-  """
+  authorized_keys: [
+    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQDBCdMwNo0xOE86il0DB2Tq4RCv07XvnV7W1uQBlOOE0ZZVjxmTIOiu8XcSLy0mHj11qX5pQH3Th6Jmyqdj",
+    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCaf37TM8GfNKcoDjoewa6021zln4GvmOiXqW6SRpF61uNWZXurPte1u8frrJX1P/hGxCL7YN3cV6eZqRiF"
+  ]
 ```
 
 The first firmware bundle that you create after adding `nerves_firmware_ssh`


### PR DESCRIPTION
Update README.md to use a List for `authorized_keys` config instead of a heredoc. The heredoc fails with

```
protocol Enumerable not implemented for "..."
```

Switching to a List resolved the issue for me.